### PR TITLE
추가/즐겨찾기/이삭줍기 카운트 백엔드

### DIFF
--- a/server/controllers/search.js
+++ b/server/controllers/search.js
@@ -19,41 +19,38 @@ exports.getSearchResults = async (req, res) => {
 
   // Get spike information
   const lecturesWithCount = await Promise.all(
-    lectures.map(
-      async (lec) =>
-        new Promise(async (res) => {
-          const [add, bookmark, spike] = await Promise.all([
-            // Add
-            Timetable.count({
-              include: {
-                model: Lecture,
-                where: {
-                  id: lec.id,
-                },
-              },
-              distinct: true,
-              col: 'userId',
-            }),
-            // Bookmark
-            UserLectureRelation.count({
-              where: { lectureId: lec.id },
-            }),
-            // Spike
-            UserLectureGleaningRelation.count({
-              where: { lectureId: lec.id },
-            }),
-          ]);
-
-          return res({
-            ...lec.dataValues,
-            count: {
-              add,
-              bookmark,
-              spike,
+    lectures.map(async (lec) => {
+      const [add, bookmark, spike] = await Promise.all([
+        // Add
+        Timetable.count({
+          include: {
+            model: Lecture,
+            where: {
+              id: lec.id,
             },
-          });
+          },
+          distinct: true,
+          col: 'userId',
         }),
-    ),
+        // Bookmark
+        UserLectureRelation.count({
+          where: { lectureId: lec.id },
+        }),
+        // Spike
+        UserLectureGleaningRelation.count({
+          where: { lectureId: lec.id },
+        }),
+      ]);
+
+      return {
+        ...lec.dataValues,
+        count: {
+          add,
+          bookmark,
+          spike,
+        },
+      };
+    }),
   );
 
   res.send({ pages: count === 0 ? 0 : Math.ceil(count / limit), lectures: lecturesWithCount });

--- a/server/controllers/search.js
+++ b/server/controllers/search.js
@@ -1,5 +1,8 @@
 const Lecture = require('../models/lecture');
 const Search = require('../models/search');
+const Timetable = require('../models/timetable');
+const UserLectureGleaningRelation = require('../models/user_lecture_gleaning_relation');
+const UserLectureRelation = require('../models/user_lecture_relation');
 const { searchWhereClause } = require('../utils/query_helper');
 
 exports.getSearchResults = async (req, res) => {
@@ -14,5 +17,44 @@ exports.getSearchResults = async (req, res) => {
     offset: page ? limit * (+page - 1) : 0,
   });
 
-  res.send({ pages: count === 0 ? 0 : Math.ceil(count / limit), lectures });
+  // Get spike information
+  const lecturesWithCount = await Promise.all(
+    lectures.map(
+      async (lec) =>
+        new Promise(async (res) => {
+          const [add, bookmark, spike] = await Promise.all([
+            // Add
+            Timetable.count({
+              include: {
+                model: Lecture,
+                where: {
+                  id: lec.id,
+                },
+              },
+              distinct: true,
+              col: 'userId',
+            }),
+            // Bookmark
+            UserLectureRelation.count({
+              where: { lectureId: lec.id },
+            }),
+            // Spike
+            UserLectureGleaningRelation.count({
+              where: { lectureId: lec.id },
+            }),
+          ]);
+
+          return res({
+            ...lec.dataValues,
+            count: {
+              add,
+              bookmark,
+              spike,
+            },
+          });
+        }),
+    ),
+  );
+
+  res.send({ pages: count === 0 ? 0 : Math.ceil(count / limit), lectures: lecturesWithCount });
 };


### PR DESCRIPTION
#48 기능 백엔드 기능입니다.

한번도 sequelize 라이브러리를 사용해 본적이 없어 기존 @zoomkoding 님의 코드를 보고 구글링을 하면서 최대한 따라해 보았습니다. 많이 부족한데, 더 좋은 방법이나 다른 접근 방법이 있으면 알려주세요!

### 추가사항

이제 검색했을 때 `count` 요소를 반환합니다.

```
{
  ...lecture,
  "count": {
      "add": 1,
      "bookmark": 0,
      "spike": 0
  }
}
```

* add - 시간표에 추가한 사람들의 인원
* bookmark - 북마크에 추가된 횟수
* spike - 이삭줍기를 신청한 사람들의 인원

부가적인 기능이므로 따로 클라이언트 업데이트는 필요 없으며 클라이언트 정보를 추가해주는 방식으로 프론트 개발을 하면 될 것 같습니다.

### 앞으로의 추가사항

클라이언트에서 북마크를 추가할 때 업데이트된 수를 확인할 수 있도록 `controllers/user.js` 파일에 있는 add/remove 함수들도 수정할 예정입니다.