### PR TITLE
feat: update timetable box

### DIFF
--- a/client/src/commons/constants.js
+++ b/client/src/commons/constants.js
@@ -8,6 +8,8 @@ export const SNACKBAR_DURATION = 2000;
 export const TIMETABLE_DAYS = ['', '월', '화', '수', '목', '금'];
 export const MAX_PERIOD = 9;
 
+export const TIMETABLE_COLORSET = ["#eddcd2", "#fff1e6", "#fde2e4", "#fad2e1", "#c5dedd", "#dbe7e4", "#f0efeb", "#d6e2e9", "#bcd4e6", "#99c1de"];
+
 export const NOTIFICATION_POSTED_AT = new Date('2022-01-13');
 
 export const SEARCH_TABS = {

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme) => {
 });
 
 export default function LectureGrid({ lecture, handleDeleteClick, bgColor, isHovered, isConnected }) {
-  const classes = useStyles({ isHovered, isConnected, bgColor });
+  const classes = useStyles({ bgColor, isHovered, isConnected });
 
   return lecture ? (
     <Box

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -15,6 +15,8 @@ const useStyles = makeStyles((theme) => {
       padding: '1px',
       overflow: 'hidden',
       cursor: 'pointer',
+      backgroundColor: (props) => (colorSet[props.colorIndex % 9]),
+      boxShadow: (props) => (props.isConnected ? '0px -3px 0px ' + colorSet[props.colorIndex % 9] : 'none'),
     },
 
     item: {
@@ -23,6 +25,7 @@ const useStyles = makeStyles((theme) => {
       textAlign: 'center',
       textOverflow: 'ellipsis',
       opacity: (props) => (props.isHovered ? 0.3 : 1),
+      display: (props) => (props.isConnected ? 'none' : 'block')
     },
 
     hoverLayer: {
@@ -31,15 +34,14 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function LectureGrid({ lecture, handleDeleteClick, colorIndex, isHovered }) {
-  const classes = useStyles({ isHovered });
+export default function LectureGrid({ lecture, handleDeleteClick, colorIndex, isHovered, isConnected }) {
+  const classes = useStyles({ isHovered, isConnected, colorIndex });
 
   return lecture ? (
     <Box
       className={classes.root}
       id={lecture.id}
       key={lecture.id}
-      style={{ backgroundColor: colorSet[colorIndex%9] }}
       onClick={() => handleDeleteClick(lecture)}
     >
       <Typography className={classes.item} variant="body2">

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => {
       textAlign: 'center',
       textOverflow: 'ellipsis',
       opacity: (props) => (props.isHovered ? 0.3 : 1),
-      display: (props) => (props.isConnected ? 'none' : 'block')
+      display: (props) => (props.isConnected ? 'none' : 'block'),
     },
 
     hoverLayer: {

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Box, Typography, makeStyles } from '@material-ui/core';
 
+const colorSet = ["#fd7f6f", "#7eb0d5", "#b2e061", "#bd7ebe", "#ffb55a", "#ffee65", "#beb9db", "#fdcce5", "#8bd3c7"];
+
 const useStyles = makeStyles((theme) => {
   return {
     root: {
@@ -29,7 +31,7 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function LectureGrid({ lecture, handleDeleteClick, isHovered }) {
+export default function LectureGrid({ lecture, handleDeleteClick, colorIndex, isHovered }) {
   const classes = useStyles({ isHovered });
 
   return lecture ? (
@@ -37,13 +39,14 @@ export default function LectureGrid({ lecture, handleDeleteClick, isHovered }) {
       className={classes.root}
       id={lecture.id}
       key={lecture.id}
+      style={{ backgroundColor: colorSet[colorIndex%9] }}
       onClick={() => handleDeleteClick(lecture)}
     >
       <Typography className={classes.item} variant="body2">
         {lecture.name}
       </Typography>
       <Typography className={classes.item}>{lecture.professor}</Typography>
-      <Typography className={classes.item}>{lecture.period}</Typography>
+      <Typography className={classes.item}>{lecture.roomNo}</Typography>
       {/* <Box className={classes.hoverLayer}>
         <DeleteIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} />
       </Box> */}

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Box, Typography, makeStyles } from '@material-ui/core';
 
-const colorSet = ["#fd7f6f", "#7eb0d5", "#b2e061", "#bd7ebe", "#ffb55a", "#ffee65", "#beb9db", "#fdcce5", "#8bd3c7"];
+// const colorSet = ["#fd7f6f", "#7eb0d5", "#b2e061", "#bd7ebe", "#ffb55a", "#ffee65", "#beb9db", "#fdcce5", "#8bd3c7"];
+// const colorSet = ["#fff1e6", "#fde2e4", "#fad2e1", "#eae4e9", "#99c1de", "#e2ece9", "#bee1e6", "#f0efeb", "#dfe7fd", "#cddafd"];
+const colorSet = ["#eddcd2", "#fff1e6", "#fde2e4", "#fad2e1", "#c5dedd", "#dbe7e4", "#f0efeb", "#d6e2e9", "#bcd4e6", "#99c1de"];
+// const colorSet = ["#f5c4bf", "#afded7", "#cbe5c4", "#f3d0bb", "#faedb7", "#f9dcb2", "#b9e5d0", "#c2d59e"]
 
 const useStyles = makeStyles((theme) => {
   return {

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import { Box, Typography, makeStyles } from '@material-ui/core';
 
-// const colorSet = ["#fd7f6f", "#7eb0d5", "#b2e061", "#bd7ebe", "#ffb55a", "#ffee65", "#beb9db", "#fdcce5", "#8bd3c7"];
-// const colorSet = ["#fff1e6", "#fde2e4", "#fad2e1", "#eae4e9", "#99c1de", "#e2ece9", "#bee1e6", "#f0efeb", "#dfe7fd", "#cddafd"];
-const colorSet = ["#eddcd2", "#fff1e6", "#fde2e4", "#fad2e1", "#c5dedd", "#dbe7e4", "#f0efeb", "#d6e2e9", "#bcd4e6", "#99c1de"];
-// const colorSet = ["#f5c4bf", "#afded7", "#cbe5c4", "#f3d0bb", "#faedb7", "#f9dcb2", "#b9e5d0", "#c2d59e"]
-
 const useStyles = makeStyles((theme) => {
   return {
     root: {
@@ -37,8 +32,7 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function LectureGrid({ lecture, handleDeleteClick, colorIndex, isHovered, isConnected }) {
-  const bgColor = colorSet[colorIndex % colorSet.length];
+export default function LectureGrid({ lecture, handleDeleteClick, bgColor, isHovered, isConnected }) {
   const classes = useStyles({ isHovered, isConnected, bgColor });
 
   return lecture ? (

--- a/client/src/components/TimetableSection/LectureGrid.js
+++ b/client/src/components/TimetableSection/LectureGrid.js
@@ -15,8 +15,8 @@ const useStyles = makeStyles((theme) => {
       padding: '1px',
       overflow: 'hidden',
       cursor: 'pointer',
-      backgroundColor: (props) => (colorSet[props.colorIndex % 9]),
-      boxShadow: (props) => (props.isConnected ? '0px -3px 0px ' + colorSet[props.colorIndex % 9] : 'none'),
+      backgroundColor: (props) => (props.bgColor),
+      boxShadow: (props) => (props.isConnected ? '0px -3px 0px ' + props.bgColor : 'none'),
     },
 
     item: {
@@ -35,7 +35,8 @@ const useStyles = makeStyles((theme) => {
 });
 
 export default function LectureGrid({ lecture, handleDeleteClick, colorIndex, isHovered, isConnected }) {
-  const classes = useStyles({ isHovered, isConnected, colorIndex });
+  const bgColor = colorSet[colorIndex % colorSet.length];
+  const classes = useStyles({ isHovered, isConnected, bgColor });
 
   return lecture ? (
     <Box

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -8,7 +8,7 @@ import Tabs from '../Tabs';
 import TimetableButtonGroup from './TimetableButtonGroup';
 import LectureGrid from './LectureGrid';
 import { sum } from '../../utils/helper';
-import { TIMETABLE_DAYS, MAX_PERIOD } from '../../commons/constants';
+import { TIMETABLE_DAYS, MAX_PERIOD, TIMETABLE_COLORSET } from '../../commons/constants';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -144,6 +144,9 @@ export default function TimetableSection({
   const lecturesForTimetable = getLecturesForTimetable(lectures);
   const [hoveredIndex, setHoveredIndex] = useState(-1);
 
+  const colorIndexByLectureId = {};
+  let colorIndex = 0;
+
   const PeriodIndicator = ({ index }) => {
     return (
       <Box className={classes.periodIndicator}>
@@ -166,8 +169,15 @@ export default function TimetableSection({
     </Box>
   );
 
-  let mapForColor = new Map();
-  let colorIndex = 0;
+  const getIsConnected = (index, lectureId) =>
+    index > TIMETABLE_DAYS.length &&
+    lecturesForTimetable[getPeriod(index - TIMETABLE_DAYS.length)]?.id === lectureId;
+
+  const getBgColor = (lectureId) => {
+    if (!(lectureId in colorIndexByLectureId))
+      colorIndexByLectureId[lectureId] = colorIndex++;
+    return TIMETABLE_COLORSET[colorIndexByLectureId[lectureId] % TIMETABLE_COLORSET.length];
+  };
 
   return (
     <Box className={classes.root}>
@@ -206,27 +216,21 @@ export default function TimetableSection({
             return <PeriodIndicator index={index} key={index} />;
 
           const period = getPeriod(index);
-          const lectureId = lecturesForTimetable[period]?.id;
-          let isConnected = false;
-          if (lectureId) {
-            if (!mapForColor.has(lectureId))
-              mapForColor.set(lectureId, colorIndex++);
-            if (index > TIMETABLE_DAYS.length && lecturesForTimetable[getPeriod(index - TIMETABLE_DAYS.length)]?.id === lectureId)
-              isConnected = true;
-          }
+          const isConnected = getIsConnected(index, lecturesForTimetable[period]?.id);
+          const bgColor = getBgColor(lecturesForTimetable[period]?.id);
 
           return (
             <Box
               className={classes.periodGrid}
               key={index}
-              onMouseOver={() => setHoveredIndex(lectureId || -1)}
+              onMouseOver={() => setHoveredIndex(lecturesForTimetable[period]?.id || -1)}
             >
               <LectureGrid
                 lecture={lecturesForTimetable[period]}
                 handleDeleteClick={isSharePage ? undefined : handleDeleteLectureClick}
                 key={index}
-                colorIndex={mapForColor.get(lectureId)}
-                isHovered={hoveredIndex === lectureId}
+                bgColor={bgColor}
+                isHovered={hoveredIndex === lecturesForTimetable[period]?.id}
                 isConnected={isConnected}
               />
             </Box>

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -166,7 +166,7 @@ export default function TimetableSection({
     </Box>
   );
 
-  var myMap = new Map();
+  var mapForColor = new Map();
   var colorIndex = 0;
 
   return (
@@ -207,8 +207,13 @@ export default function TimetableSection({
 
           const period = getPeriod(index);
           const lectureId = lecturesForTimetable[period]?.id;
-          if (lectureId && !myMap.has(lectureId))
-            myMap.set(lectureId, colorIndex++);
+          var isConnected = false;
+          if (lectureId) {
+            if (lectureId && !mapForColor.has(lectureId))
+              mapForColor.set(lectureId, colorIndex++);
+            if (index > TIMETABLE_DAYS.length && lecturesForTimetable[getPeriod(index - TIMETABLE_DAYS.length)]?.id === lectureId)
+              isConnected = true;
+          }
 
           return (
             <Box
@@ -220,8 +225,9 @@ export default function TimetableSection({
                 lecture={lecturesForTimetable[period]}
                 handleDeleteClick={isSharePage ? undefined : handleDeleteLectureClick}
                 key={index}
-                colorIndex={myMap.get(lectureId)}
+                colorIndex={mapForColor.get(lectureId)}
                 isHovered={hoveredIndex === lectureId}
+                isConnected={isConnected}
               />
             </Box>
           );

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -209,7 +209,7 @@ export default function TimetableSection({
           const lectureId = lecturesForTimetable[period]?.id;
           var isConnected = false;
           if (lectureId) {
-            if (lectureId && !mapForColor.has(lectureId))
+            if (!mapForColor.has(lectureId))
               mapForColor.set(lectureId, colorIndex++);
             if (index > TIMETABLE_DAYS.length && lecturesForTimetable[getPeriod(index - TIMETABLE_DAYS.length)]?.id === lectureId)
               isConnected = true;

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
     width: '100%',
     height: '100%',
-    padding: '1px',
+    padding: '0px',
     borderBottom: '1px solid #eaedf1',
     borderRight: '1px solid #eaedf1',
   },
@@ -166,8 +166,8 @@ export default function TimetableSection({
     </Box>
   );
 
-  var mapForColor = new Map();
-  var colorIndex = 0;
+  let mapForColor = new Map();
+  let colorIndex = 0;
 
   return (
     <Box className={classes.root}>
@@ -207,7 +207,7 @@ export default function TimetableSection({
 
           const period = getPeriod(index);
           const lectureId = lecturesForTimetable[period]?.id;
-          var isConnected = false;
+          let isConnected = false;
           if (lectureId) {
             if (!mapForColor.has(lectureId))
               mapForColor.set(lectureId, colorIndex++);

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -166,6 +166,9 @@ export default function TimetableSection({
     </Box>
   );
 
+  var myMap = new Map();
+  var colorIndex = 0;
+
   return (
     <Box className={classes.root}>
       <Box className={classes.header}>
@@ -203,18 +206,22 @@ export default function TimetableSection({
             return <PeriodIndicator index={index} key={index} />;
 
           const period = getPeriod(index);
+          const lectureId = lecturesForTimetable[period]?.id;
+          if (lectureId && !myMap.has(lectureId))
+            myMap.set(lectureId, colorIndex++);
 
           return (
             <Box
               className={classes.periodGrid}
               key={index}
-              onMouseOver={() => setHoveredIndex(lecturesForTimetable[period]?.id || -1)}
+              onMouseOver={() => setHoveredIndex(lectureId || -1)}
             >
               <LectureGrid
                 lecture={lecturesForTimetable[period]}
                 handleDeleteClick={isSharePage ? undefined : handleDeleteLectureClick}
                 key={index}
-                isHovered={hoveredIndex === lecturesForTimetable[period]?.id}
+                colorIndex={myMap.get(lectureId)}
+                isHovered={hoveredIndex === lectureId}
               />
             </Box>
           );

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -84,7 +84,6 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
     width: '100%',
     height: '100%',
-    padding: '0px',
     borderBottom: '1px solid #eaedf1',
     borderRight: '1px solid #eaedf1',
   },
@@ -216,21 +215,22 @@ export default function TimetableSection({
             return <PeriodIndicator index={index} key={index} />;
 
           const period = getPeriod(index);
-          const isConnected = getIsConnected(index, lecturesForTimetable[period]?.id);
-          const bgColor = getBgColor(lecturesForTimetable[period]?.id);
+          const lectureId = lecturesForTimetable[period]?.id;
+          const isConnected = getIsConnected(index, lectureId);
+          const bgColor = getBgColor(lectureId);
 
           return (
             <Box
               className={classes.periodGrid}
               key={index}
-              onMouseOver={() => setHoveredIndex(lecturesForTimetable[period]?.id || -1)}
+              onMouseOver={() => setHoveredIndex(lectureId || -1)}
             >
               <LectureGrid
                 lecture={lecturesForTimetable[period]}
                 handleDeleteClick={isSharePage ? undefined : handleDeleteLectureClick}
                 key={index}
                 bgColor={bgColor}
-                isHovered={hoveredIndex === lecturesForTimetable[period]?.id}
+                isHovered={hoveredIndex === lectureId}
                 isConnected={isConnected}
               />
             </Box>

--- a/client/src/components/TimetableSection/index.js
+++ b/client/src/components/TimetableSection/index.js
@@ -216,8 +216,6 @@ export default function TimetableSection({
 
           const period = getPeriod(index);
           const lectureId = lecturesForTimetable[period]?.id;
-          const isConnected = getIsConnected(index, lectureId);
-          const bgColor = getBgColor(lectureId);
 
           return (
             <Box
@@ -229,9 +227,9 @@ export default function TimetableSection({
                 lecture={lecturesForTimetable[period]}
                 handleDeleteClick={isSharePage ? undefined : handleDeleteLectureClick}
                 key={index}
-                bgColor={bgColor}
+                bgColor={getBgColor(lectureId)}
                 isHovered={hoveredIndex === lectureId}
-                isConnected={isConnected}
+                isConnected={getIsConnected(index, lectureId)}
               />
             </Box>
           );


### PR DESCRIPTION
#52 해당 이슈 내용과 코멘트를 반영했습니다.

변경사항
---
- 시간표에서 과목 시간 정보를 강의실 위치 정보로 변경하였습니다.
- 색을 추가해서 같은 과목은 같은 색을 가지게 했습니다.
- 연강의 경우 수업 박스를 병합했습니다.

### Before
<img width="1440" alt="스크린샷 2022-01-23 오후 11 50 09" src="https://user-images.githubusercontent.com/79754613/150684284-0529b247-b615-4857-9731-47b79d6920c4.png">

### After
<img width="1440" alt="스크린샷 2022-01-23 오후 11 48 59" src="https://user-images.githubusercontent.com/79754613/150684286-dd10b4e3-bf17-4552-b02d-2262e9e3e248.png">

<br>
코드리뷰 부탁드립니다! 또 추가로 변경을 원하는 부분이 있으면 알려주세용☺️